### PR TITLE
Remove unnecessary components and comments

### DIFF
--- a/app/library/components/Containers/Accordion/Accordion.jsx
+++ b/app/library/components/Containers/Accordion/Accordion.jsx
@@ -1,10 +1,6 @@
 import React from 'react';
 import AccordionPanel from './AccordionPanel';
 
-/* ==========================================================================
-   React Component
-========================================================================== */
-
 class Accordion extends React.Component {
 
   constructor(props) {

--- a/app/library/components/Containers/Accordion/AccordionPanel.jsx
+++ b/app/library/components/Containers/Accordion/AccordionPanel.jsx
@@ -3,12 +3,7 @@ import ReactDom from 'react-dom';
 import tc from 'tinycolor2';
 import styled, { css } from 'styled-components';
 
-
-/* ==========================================================================
-   Styles
-========================================================================== */
-
-const Container = styled.div`
+const AccordionPanelInner = styled.div`
   ${({ theme }) => css`
     margin-bottom: 0;
     background-color: white;
@@ -40,6 +35,7 @@ const Heading = styled.div`
     text-decoration: none!important;
     &:hover {
       background-color: ${isOpen ? tc(theme.colors.gray_lightest).darken(7).toString() : tc(theme.colors.gray_lightest).darken(3).toString()};
+      cursor: pointer;
       /* > $//{Title} {
         color: red;
       }*/
@@ -59,10 +55,6 @@ const BodyInner = styled.div`
     padding: ${theme.components.padding_base_vertical} ${theme.components.padding_base_horizontal};
   `}
 `;
-
-/* ==========================================================================
-   React Component
-========================================================================== */
 
 class AccordionPanel extends React.Component {
 
@@ -90,7 +82,7 @@ class AccordionPanel extends React.Component {
   render() {
     const { title, children, isOpen, onClick } = this.props;
     return (
-      <Container onClick={onClick}>
+      <AccordionPanelInner onClick={onClick}>
         <Heading href="#" isOpen={isOpen}>
           <Title>{title}</Title>
         </Heading>
@@ -103,7 +95,7 @@ class AccordionPanel extends React.Component {
             {children}
           </BodyInner>
         </Body>
-      </Container>
+      </AccordionPanelInner>
     );
   }
 

--- a/app/library/components/Data/List/List.jsx
+++ b/app/library/components/Data/List/List.jsx
@@ -1,10 +1,6 @@
 import React from 'react';
 import styled, { css } from 'styled-components';
 
-/* ==========================================================================
-   Styles
-========================================================================== */
-
 const List = styled.ul`
   ${({ theme, hasBullets, isSpaced, isInline }) => css`
     margin: 0 0 ${theme.components.spacing_vertical} 0;
@@ -25,10 +21,6 @@ const List = styled.ul`
     }
   `}
 `;
-
-/* ==========================================================================
-   React Component
-========================================================================== */
 
 List.propTypes = {
   hasBullets: React.PropTypes.bool,

--- a/app/library/components/Data/Table/Table.jsx
+++ b/app/library/components/Data/Table/Table.jsx
@@ -2,10 +2,6 @@ import React from 'react';
 import styled, { css } from 'styled-components';
 import tinycolor from 'tinycolor2';
 
-/* ==========================================================================
-   Styles
-========================================================================== */
-
 const Container = styled.div`
   ${({ theme, breakpoint }) => css`
     overflow-x: auto;
@@ -79,10 +75,6 @@ const InnerTable = styled.table`
     }
   `}
 `;
-
-/* ==========================================================================
-   React Component
-========================================================================== */
 
 const Table = ({ children, isLight, isHover, isStriped, breakpoint }) => (
   <Container breakpoint={breakpoint}>

--- a/app/library/components/Decoration/Label/Label.jsx
+++ b/app/library/components/Decoration/Label/Label.jsx
@@ -1,11 +1,6 @@
 import React from 'react';
 import styled, { css } from 'styled-components';
 
-
-/* ==========================================================================
-   Styles
-========================================================================== */
-
 const Default = styled.span`
   ${({ theme }) => css`
     display: inline;
@@ -40,10 +35,6 @@ const Warning = styled(Default)`
 const Info = styled(Default)`
   background-color: ${props => props.theme.colors.states.info};
 `;
-
-/* ==========================================================================
-   React Component
-========================================================================== */
 
 class Label extends React.Component {
   render() {

--- a/app/library/components/Form/Button/Button.jsx
+++ b/app/library/components/Form/Button/Button.jsx
@@ -3,11 +3,6 @@ import styled, { css } from 'styled-components';
 import tc from 'tinycolor2';
 import { Link } from 'react-router';
 
-
-/* ==========================================================================
-   Styles
-========================================================================== */
-
 const Default = styled(Link)`
   ${({ theme, isSmall, isBlock }) => css`
     display: ${isBlock ? 'block' : 'inline-block'};
@@ -191,10 +186,6 @@ const LinkButton = styled(Default)`
     }
   `}
 `;
-
-/* ==========================================================================
-   React Component
-========================================================================== */
 
 export const Button = ({ theme, children, type, isSmall, isBlock, isDisabled, onClick, href, to }) => {
   const InnerButton = (() => {

--- a/app/library/components/Form/ButtonGroup/ButtonGroup.jsx
+++ b/app/library/components/Form/ButtonGroup/ButtonGroup.jsx
@@ -1,12 +1,7 @@
 import React from 'react';
 import styled, { css } from 'styled-components';
 
-
-/* ==========================================================================
-   Styles
-========================================================================== */
-
-const Group = styled.div`
+const ButtonGroup = styled.div`
   ${({ isJustified }) => css`
     display: ${isJustified ? 'table' : 'inline-block'};
     width: ${isJustified ? '100%' : 'auto'};
@@ -19,8 +14,7 @@ const Group = styled.div`
       float: left;
       &:hover,
       &:focus,
-      &:active,
-      &.is-active {
+      &:active {
         z-index: 2;
       }
     }
@@ -48,17 +42,6 @@ const Group = styled.div`
     }`}
   `}
 `;
-
-
-/* ==========================================================================
-   React Component
-========================================================================== */
-
-export const ButtonGroup = ({ isJustified, children }) => (
-  <Group isJustified={isJustified}>
-    {children}
-  </Group>
-);
 
 ButtonGroup.propTypes = {
   isJustified: React.PropTypes.bool,

--- a/app/library/components/Form/InputGroup/InputGroup.jsx
+++ b/app/library/components/Form/InputGroup/InputGroup.jsx
@@ -1,10 +1,29 @@
 import React from 'react';
 import styled, { css } from 'styled-components';
 
-
-/* ==========================================================================
-   Styles
-========================================================================== */
+const InputGroupInner = styled.div`
+  position: relative;
+  display: table;
+  border-collapse: separate;
+  > input {
+    position: relative;
+    z-index: 2;
+    float: left;
+    width: 100%;
+    margin-bottom: 0;
+    &:first-child {
+      border-top-right-radius: 0;
+      border-bottom-right-radius: 0;
+    }
+    &:last-child {
+      border-top-left-radius: 0;
+      border-bottom-left-radius: 0;
+    }
+    &:not(:first-child):not(:last-child) {
+      border-radius: 0;
+    }
+  }
+`;
 
 const AddonString = styled.span`
   ${({ theme }) => css`
@@ -65,35 +84,6 @@ const AddonButton = styled.span`
   }
 `;
 
-const Container = styled.div`
-  position: relative;
-  display: table;
-  border-collapse: separate;
-  > input {
-    position: relative;
-    z-index: 2;
-    float: left;
-    width: 100%;
-    margin-bottom: 0;
-    &:first-child {
-      border-top-right-radius: 0;
-      border-bottom-right-radius: 0;
-    }
-    &:last-child {
-      border-top-left-radius: 0;
-      border-bottom-left-radius: 0;
-    }
-    &:not(:first-child):not(:last-child) {
-      border-radius: 0;
-    }
-  }
-`;
-
-
-/* ==========================================================================
-   React Component
-========================================================================== */
-
 export const InputGroup = ({ children, start, end }) => {
   let AddonStart;
   let AddonEnd;
@@ -110,11 +100,11 @@ export const InputGroup = ({ children, start, end }) => {
     AddonEnd = <AddonButton>{end}</AddonButton>;
   }
   return (
-    <Container>
+    <InputGroupInner>
       {AddonStart}
       {children}
       {AddonEnd}
-    </Container>
+    </InputGroupInner>
   );
 };
 

--- a/app/library/components/Form/InputPassword/InputPassword.jsx
+++ b/app/library/components/Form/InputPassword/InputPassword.jsx
@@ -1,20 +1,8 @@
 import React from 'react';
-import styled from 'styled-components';
 import InputText from '../InputText';
 
-
-/* ==========================================================================
-   Styles
-========================================================================== */
-
-const Input = styled(InputText)``;
-
-/* ==========================================================================
-   React Component
-========================================================================== */
-
 export const InputPassword = ({ placeholder }) => (
-  <Input placeholder={placeholder} type="password" />
+  <InputText placeholder={placeholder} type="password" />
 );
 
 InputPassword.propTypes = {

--- a/app/library/components/Form/InputText/InputText.jsx
+++ b/app/library/components/Form/InputText/InputText.jsx
@@ -1,12 +1,7 @@
 import React from 'react';
 import styled, { css } from 'styled-components';
 
-
-/* ==========================================================================
-   Styles
-========================================================================== */
-
-const Input = styled.input`
+const InputTextInner = styled.input`
   ${({ theme, isSmall }) => css`
     padding: ${isSmall ?
       `${theme.components.padding_base_vertical} ${theme.components.padding_base_horizontal}` :
@@ -30,13 +25,6 @@ const Input = styled.input`
       box-shadow: inset 0 0.1rem 0.1rem rgba(0,0,0,.075), 0 0 0.8rem rgba(102, 175, 233, 0.6);
     }
 
-    /* Fix: Unstyle the caret on <select>s in IE10+. */
-    &::-ms-expand {
-        border: 0;
-        background-color: transparent;
-    }
-
-    /* Disabled and read-only inputs */
     &[disabled],
     &[readonly] {
         background-color: ${theme.forms.input_bg_disabled};
@@ -48,13 +36,8 @@ const Input = styled.input`
   `}
 `;
 
-
-/* ==========================================================================
-   React Component
-========================================================================== */
-
 export const InputText = ({ placeholder, type, isSmall }) => (
-  <Input placeholder={placeholder} type={type} isSmall={isSmall} />
+  <InputTextInner placeholder={placeholder} type={type} isSmall={isSmall} />
 );
 
 InputText.propTypes = {

--- a/app/library/components/Form/Textarea/Textarea.jsx
+++ b/app/library/components/Form/Textarea/Textarea.jsx
@@ -1,10 +1,6 @@
 import React from 'react';
 import styled, { css } from 'styled-components';
 
-/* ==========================================================================
-   Styles
-========================================================================== */
-
 const TextArea = styled.textarea`
   ${({ theme }) => css`
     padding: ${theme.components.padding_base_vertical} ${theme.components.padding_base_horizontal};
@@ -29,7 +25,6 @@ const TextArea = styled.textarea`
       box-shadow: inset 0 0.1rem 0.1rem rgba(0,0,0,.075), 0 0 0.8rem rgba(102, 175, 233, 0.6);
     }
 
-    // Disabled and read-only inputs
     &[disabled],
     &[readonly] {
         background-color: ${theme.forms.input_bg_disabled};
@@ -40,11 +35,6 @@ const TextArea = styled.textarea`
     }
   `}
 `;
-
-
-/* ==========================================================================
-   React Component
-========================================================================== */
 
 export const InputTextArea = ({ rows }) => (
   <TextArea rows={rows} />

--- a/app/library/components/Layout/Float/Float.jsx
+++ b/app/library/components/Layout/Float/Float.jsx
@@ -1,24 +1,9 @@
 import React from 'react';
 import styled from 'styled-components';
 
-
-/* ==========================================================================
-   Styles
-========================================================================== */
-
-const Container = styled.div`
+const Float = styled.div`
   float: ${props => props.right ? 'right' : 'left'};
 `;
-
-/* ==========================================================================
-   React Component
-========================================================================== */
-
-export const Float = ({ children, right }) => (
-  <Container right={right}>
-    {children}
-  </Container>
-);
 
 Float.propTypes = {
   right: React.PropTypes.bool,

--- a/app/library/components/Layout/Position/Position.jsx
+++ b/app/library/components/Layout/Position/Position.jsx
@@ -1,12 +1,7 @@
 import React from 'react';
 import styled, { css } from 'styled-components';
 
-
-/* ==========================================================================
-   Styles
-========================================================================== */
-
-const Container = styled.div`
+const Position = styled.div`
   ${({ fixed, zindex, top, right, bottom, left }) => css`
     position: ${fixed ? 'fixed' : 'absolute'};
     z-index: ${zindex || '1'};
@@ -16,16 +11,6 @@ const Container = styled.div`
     left: ${left ? '0' : 'auto'};
   `}
 `;
-
-/* ==========================================================================
-   React Component
-========================================================================== */
-
-export const Position = ({ children, fixed, zindex, top, right, bottom, left }) => (
-  <Container fixed={fixed} zindex={zindex} top={top} right={right} bottom={bottom} left={left}>
-    {children}
-  </Container>
-);
 
 Position.propTypes = {
   fixed: React.PropTypes.bool,

--- a/app/library/components/Navigation/Bar/Bar.jsx
+++ b/app/library/components/Navigation/Bar/Bar.jsx
@@ -1,12 +1,7 @@
 import React from 'react';
 import styled, { css } from 'styled-components';
 
-
-/* ==========================================================================
-   Styles
-========================================================================== */
-
-const Container = styled.div`
+const Bar = styled.div`
   ${({ theme }) => css`
     margin: 0;
     height: 6rem;
@@ -15,16 +10,6 @@ const Container = styled.div`
     box-shadow: ${theme.components.shadow};
   `}
 `;
-
-/* ==========================================================================
-   React Component
-========================================================================== */
-
-export const Bar = ({ children }) => (
-  <Container>
-    {children}
-  </Container>
-);
 
 Bar.propTypes = {
   children: React.PropTypes.node.isRequired,

--- a/app/library/components/Navigation/Bar/BarMenu.jsx
+++ b/app/library/components/Navigation/Bar/BarMenu.jsx
@@ -2,10 +2,6 @@ import React from 'react';
 import styled from 'styled-components';
 import { Link as RouterLink } from 'react-router';
 
-/* ==========================================================================
-   Styles
-========================================================================== */
-
 const BarMenu = styled.ul`
   margin: 0;
   padding: 0;
@@ -36,10 +32,6 @@ const Link = styled(RouterLink)`
     text-decoration:inherit;
   }
 `;
-
-/* ==========================================================================
-   React Component
-========================================================================== */
 
 const BarMenuItem = ({ children, href, to }) => (
   <Item>

--- a/app/library/components/Navigation/Dropdown/Dropdown.jsx
+++ b/app/library/components/Navigation/Dropdown/Dropdown.jsx
@@ -1,11 +1,6 @@
 import React from 'react';
 import styled, { css } from 'styled-components';
 
-
-/* ==========================================================================
-   Styles
-========================================================================== */
-
 const Container = styled.div`
   display: inline-block;
   position: relative;
@@ -23,10 +18,6 @@ const Menu = styled.div`
     box-shadow: ${theme.components.shadow_large};
   `}
 `;
-
-/* ==========================================================================
-   React Component
-========================================================================== */
 
 class Dropdown extends React.Component {
 

--- a/app/library/components/Navigation/Menu/Menu.jsx
+++ b/app/library/components/Navigation/Menu/Menu.jsx
@@ -3,11 +3,7 @@ import styled, { css } from 'styled-components';
 import tc from 'tinycolor2';
 import { Link as RouterLink } from 'react-router';
 
-/* ==========================================================================
-   Styles
-========================================================================== */
-
-export const Menu = styled.ul`
+const Menu = styled.ul`
   margin: 0;
   padding: 0;
   list-style: none;
@@ -51,11 +47,7 @@ const Link = styled(RouterLink)`
   `}
 `;
 
-/* ==========================================================================
-   React Component
-========================================================================== */
-
-export const MenuItem = ({ children, href, to, icon, description, isActive }) => (
+const MenuItem = ({ children, href, to, icon, description, isActive }) => (
   <Item>
     <Link href={href} to={to} isActive={isActive}>
       {icon && <Icon>{icon}</Icon> }
@@ -85,3 +77,5 @@ MenuItem.defaultProps = {
   description: null,
   isActive: false,
 };
+
+export { Menu, MenuItem };

--- a/app/library/components/Status/Alert/Alert.jsx
+++ b/app/library/components/Status/Alert/Alert.jsx
@@ -2,11 +2,6 @@ import React from 'react';
 import styled, { css } from 'styled-components';
 import tinycolor from 'tinycolor2';
 
-
-/* ==========================================================================
-   Styles
-========================================================================== */
-
 const Default = styled.div`
   ${({ theme, hasArrow }) => css`
     position: relative;
@@ -84,11 +79,6 @@ const Header = styled.div`
 const Description = styled.div`
   margin: 0;
 `;
-
-
-/* ==========================================================================
-   React Component
-========================================================================== */
 
 class Alert extends React.Component {
   render() {


### PR DESCRIPTION
Removes comments that separate style from logic, as the lines are a bit more blurred for simpler components.
Ran through all components and removed pointless components, just export the styled-component straight away where possible.
Also standardizes the way we do naming, e.g. Component, ComponentInner, Default. 
Plus other tiny fixes.